### PR TITLE
Remove ad capturing for iOS

### DIFF
--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -12,7 +12,7 @@
     "dev-android": "cd ../core && yalc publish && cd ../TestApp && yalc update posthog-react-native && yarn && react-native link && yarn run android"
   },
   "dependencies": {
-    "posthog-react-native": "1.0.1",
+    "posthog-react-native": "1.1.0",
     "react": "16.11.0",
     "react-native": "0.62.2"
   },

--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -12,7 +12,7 @@
     "dev-android": "cd ../core && yalc publish && cd ../TestApp && yalc update posthog-react-native && yarn && react-native link && yarn run android"
   },
   "dependencies": {
-    "posthog-react-native": "file:.yalc/posthog-react-native",
+    "posthog-react-native": "1.0.1",
     "react": "16.11.0",
     "react-native": "0.62.2"
   },

--- a/TestApp/yalc.lock
+++ b/TestApp/yalc.lock
@@ -1,9 +1,0 @@
-{
-  "version": "v1",
-  "packages": {
-    "posthog-react-native": {
-      "signature": "d2999febec00e1f25acc12b6ad4a99a4",
-      "file": true
-    }
-  }
-}

--- a/core/RNPostHog.podspec
+++ b/core/RNPostHog.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{m,h}'
   s.static_framework    = true
 
-  s.dependency          'PostHog', '~> 1.0.3'
+  s.dependency          'PostHog', '~> 1.0.4'
   s.dependency          'React'
 end

--- a/core/RNPostHog.podspec
+++ b/core/RNPostHog.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{m,h}'
   s.static_framework    = true
 
-  s.dependency          'PostHog', '~> 1.0.4'
+  s.dependency          'PostHog', '~> 1.2.1'
   s.dependency          'React'
 end

--- a/core/ios/RNPostHog/RNPostHog.m
+++ b/core/ios/RNPostHog/RNPostHog.m
@@ -43,7 +43,6 @@ RCT_EXPORT_METHOD(
     config.flushAt = [options[@"flushAt"] integerValue];
     config.flushInterval = [options[@"flushInterval"] integerValue];
 
-    config.enableAdvertisingCapturing = [options[@"ios"][@"enableAdvertisingCapturing"] boolValue];
     config.capturePushNotifications = [options[@"ios"][@"capturePushNotifications"] boolValue];
     config.captureInAppPurchases = [options[@"ios"][@"captureInAppPurchases"] boolValue];
     config.shouldUseBluetooth = [options[@"ios"][@"shouldUseBluetooth"] boolValue];

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The hassle-free way to add PostHog to your React-Native app.",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "The hassle-free way to add PostHog to your React-Native app.",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/core/src/__tests__/configuration.spec.ts
+++ b/core/src/__tests__/configuration.spec.ts
@@ -29,7 +29,6 @@ it('uses the default configuration', async () => {
 			ios: {
 				captureInAppPurchases: false,
 				capturePushNotifications: false,
-				enableAdvertisingCapturing: true,
 				maxQueueSize: 1000,
 				shouldUseBluetooth: false,
 				shouldUseLocationServices: false
@@ -71,7 +70,6 @@ it('produces a valid configuration', async () => {
 			ios: {
 				captureInAppPurchases: false,
 				capturePushNotifications: true,
-				enableAdvertisingCapturing: true,
 				maxQueueSize: 1000,
 				shouldUseBluetooth: false,
 				shouldUseLocationServices: false

--- a/core/src/bridge.ts
+++ b/core/src/bridge.ts
@@ -20,7 +20,6 @@ export interface Configuration {
 		collectDeviceId?: boolean
 	}
 	ios: {
-		enableAdvertisingCapturing?: boolean
 		capturePushNotifications?: boolean
 		captureInAppPurchases?: boolean
 		maxQueueSize?: number

--- a/core/src/configuration.ts
+++ b/core/src/configuration.ts
@@ -6,7 +6,6 @@ const defaults = {
 		collectDeviceId
 	}),
 	ios: ({
-		enableAdvertisingCapturing = true,
 		capturePushNotifications = false,
 		captureInAppPurchases = false,
 		shouldUseBluetooth = false,
@@ -15,7 +14,6 @@ const defaults = {
 	}: Partial<Configuration['ios']>) => ({
 		captureInAppPurchases,
 		capturePushNotifications,
-		enableAdvertisingCapturing,
 		maxQueueSize,
 		shouldUseBluetooth,
 		shouldUseLocationServices

--- a/core/src/posthog.ts
+++ b/core/src/posthog.ts
@@ -64,12 +64,6 @@ export module PostHog {
 		 */
 		ios?: {
 			/**
-			 * Whether the posthog client should capture advertisting info.
-			 *
-			 * Enabled by default.
-			 */
-			enableAdvertisingCapturing?: boolean
-			/**
 			 * Whether the posthog client should use location services.
 			 * If `true` and the host app hasn't asked for permission to use location services then the user will be
 			 * presented with an alert view asking to do so. `false` by default. If `true`, please make sure to add a
@@ -182,7 +176,7 @@ export module PostHog {
 		 * await posthog.setup('YOUR_API_KEY', {
 		 *   captureAppLifecycleEvents: true,
 		 *   ios: {
-		 *     enableAdvertisingCapturing: true
+		 *     capturePushNotifications: true
 		 *   }
 		 * })
 		 * ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -7807,9 +7807,6 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-"posthog-react-native@file:TestApp/.yalc/posthog-react-native":
-  version "1.0.0-2c200957"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
- Upgrade to PostHog-iOS 1.2.1
- Remove removed `enableAdvertisingCapturing`
- Release 1.1.0