### PR TITLE
Set default kotlin version to 1.3.50

### DIFF
--- a/core/android/build.gradle
+++ b/core/android/build.gradle
@@ -6,7 +6,7 @@ def safeExtGet(prop, fallback) {
 }
 
 buildscript {
-    ext.defaultKotlinVersion = '1.3.21'
+    ext.defaultKotlinVersion = '1.3.50'
 
     repositories {
         jcenter()


### PR DESCRIPTION
Fix for [issue#42](https://github.com/PostHog/posthog-react-native/issues/42)

Error:
```
Task :posthog-react-native:compileReleaseKotlin
e: .../node_modules/posthog-react-native/android/src/main/java/com/posthog/reactnative/core/RNPostHogModule.kt: (236, 27): 'forEach((Map.Entry<K, V>) -> Unit): Unit' is only available since Kotlin 1.3.50 and cannot be used in Kotlin 1.3
```

Solution: 
update kotlin version in build.gradle `ext.defaultKotlinVersion = '1.3.50'`