### PR TITLE
[Android] Bug: Allow null for distinctId param when calling `.identify`

### DIFF
--- a/core/android/src/main/java/com/posthog/reactnative/core/RNPostHogModule.kt
+++ b/core/android/src/main/java/com/posthog/reactnative/core/RNPostHogModule.kt
@@ -201,7 +201,8 @@ class RNPostHogModule(context: ReactApplicationContext): ReactContextBaseJavaMod
     fun identify(distinctId: String?, properties: ReadableMap?) =
             posthog.identify(
                     distinctId,
-                    Properties() from properties
+                    Properties() from properties,
+                    null
             )
 
     @ReactMethod

--- a/core/android/src/main/java/com/posthog/reactnative/core/RNPostHogModule.kt
+++ b/core/android/src/main/java/com/posthog/reactnative/core/RNPostHogModule.kt
@@ -198,7 +198,7 @@ class RNPostHogModule(context: ReactApplicationContext): ReactContextBaseJavaMod
             )
 
     @ReactMethod
-    fun identify(distinctId: String, properties: ReadableMap?) =
+    fun identify(distinctId: String?, properties: ReadableMap?) =
             posthog.identify(
                     distinctId,
                     Properties() from properties

--- a/core/src/__tests__/posthog.spec.ts
+++ b/core/src/__tests__/posthog.spec.ts
@@ -56,6 +56,8 @@ it('does .screen()', () => testCall('screen')('Shopping cart', { from: 'Product 
 
 it('does .identify()', () => testCall('identify')('sloth', { eats: 'leaves' }))
 
+it('does .identify() with null', () => testCall('identify')(null, { eats: 'leaves' }))
+
 it('does .alias()', () => testCall('alias')('new alias'))
 
 it('does .reset()', testCall('reset'))

--- a/core/src/bridge.ts
+++ b/core/src/bridge.ts
@@ -42,7 +42,7 @@ export interface Options {
 export interface Bridge {
 	setup(configuration: Configuration): Promise<void>
 	capture(event: string, properties: JsonMap): Promise<void>
-	identify(distinctId: string, properties: JsonMap): Promise<void>
+	identify(distinctId: string | null, properties: JsonMap): Promise<void>
 	screen(screen: string, properties: JsonMap): Promise<void>
 	alias(alias: string): Promise<void>
 	reset(): Promise<void>

--- a/core/src/middleware.ts
+++ b/core/src/middleware.ts
@@ -33,7 +33,7 @@ export interface IdentifyPayload
 	extends MiddlewarePayload<
 		'identify',
 		{
-			distinctId: string
+			distinctId: string | null
 			properties: JsonMap
 		}
 	> {}

--- a/core/src/posthog.ts
+++ b/core/src/posthog.ts
@@ -229,7 +229,7 @@ export module PostHog {
 		 * If you don't have a userId but want to record traits, you should pass nil.
 		 * @param properties A dictionary of properties you know about the user. Things like: email, name, plan, etc.
 		 */
-		public async identify(distinctId: string, properties: JsonMap = {}) {
+		public async identify(distinctId: string | null, properties: JsonMap = {}) {
 			await this.middlewares.run('identify', { distinctId, properties })
 		}
 


### PR DESCRIPTION
Hi there,

We have been using `posthog-react-native` in our project on iOS for some time now, we just recently spent the time to get Android up and running. When doing so, we noticed a crash when the application mounted due to `checkParameterIsNotNull`. Posthog docs specifically mention to pass `null` when the `distinctId` is not known. Passing `null` works on iOS.

Let me know if I need to do anything else for this PR! Thanks!

This fixes the issue I opened up https://github.com/PostHog/posthog-react-native/issues/49