### PR TITLE
Fix unresolved/unused reference Traits after upgrading dependency

### DIFF
--- a/core/android/src/main/java/com/posthog/reactnative/core/RNPostHogModule.kt
+++ b/core/android/src/main/java/com/posthog/reactnative/core/RNPostHogModule.kt
@@ -32,7 +32,6 @@ import com.facebook.react.bridge.*
 import com.posthog.android.PostHog
 import com.posthog.android.Options
 import com.posthog.android.Properties
-import com.posthog.android.Traits
 import com.posthog.android.ValueMap
 import com.posthog.android.internal.Utils.getPostHogSharedPreferences
 import java.util.concurrent.TimeUnit


### PR DESCRIPTION
This was found after upgrading to posthog-react-native 1.1.4 which upgraded the android dependency of posthog to 1.1.2. I believe the Traits model, which this module isnt using, was removed and is causing android builds to fail. 